### PR TITLE
Update skins for WoW Midnight (12.0.1, interface 120001)

### DIFF
--- a/AddOnSkins/AddOnSkins.toc
+++ b/AddOnSkins/AddOnSkins.toc
@@ -1,6 +1,6 @@
-## Interface: 110107
+## Interface: 120001
 ## Title: |cff16C3F2AddOn|r|cFFFFFFFFSkins|r
-## Version: 4.73
+## Version: 4.79
 ## Author: Azilroka, Nihilistzsche
 ## SavedVariables: AddOnSkinsDB, AddOnSkinsDS
 ## OptionalDeps: AllTheThings, ElvUI

--- a/AddOnSkins/Skins/AddOns/AllTheThings.lua
+++ b/AddOnSkins/Skins/AddOns/AllTheThings.lua
@@ -1,14 +1,35 @@
 local AS, L, S, R = unpack(AddOnSkins)
 
-function R:AllTheThings()
-	for _, Instance in pairs({ 'Prime', 'CurrentInstance', 'WorldQuests' }) do
-		local Window = AllTheThings:GetWindow(Instance)
-		S:SetTemplate(Window)
-		S:HandleCloseButton(Window.CloseButton)
+local windowsToSkin = { Prime = true, CurrentInstance = true, WorldQuests = true }
+
+local function SkinATTWindow(Window)
+	if not Window or Window.ATT_Skinned then return end
+	Window.ATT_Skinned = true
+
+	S:SetTemplate(Window)
+
+	if Window.CloseButton then S:HandleCloseButton(Window.CloseButton) end
+	if Window.ScrollBar then
 		S:HandleScrollBar(Window.ScrollBar)
-		Window.Container:SetPoint("RIGHT", Window.ScrollBar, "LEFT", -3, 0)
+		if Window.Container then
+			Window.Container:SetPoint("RIGHT", Window.ScrollBar, "LEFT", -3, 0)
+		end
+	end
+end
+
+function R:AllTheThings()
+	if not AllTheThings or not AllTheThings.GetWindow then return end
+
+	-- Wrap GetWindow so we skin windows lazily when ATT initializes them,
+	-- rather than calling GetWindow ourselves and creating bare frames prematurely.
+	local origGetWindow = AllTheThings.GetWindow
+	AllTheThings.GetWindow = function(addon, name)
+		local win = origGetWindow(addon, name)
+		if windowsToSkin[name] and win then
+			SkinATTWindow(win)
+		end
+		return win
 	end
 end
 
 AS:RegisterSkin('AllTheThings')
-

--- a/AddOnSkins/Skins/AddOns/RareScanner.lua
+++ b/AddOnSkins/Skins/AddOns/RareScanner.lua
@@ -1,18 +1,33 @@
 local AS, L, S, R = unpack(AddOnSkins)
 
 function R:RareScanner()
-	S:HandleFrame(RARESCANNER_BUTTON, 'Default')
-	S:HandleButton(RARESCANNER_BUTTON.CloseButton)
-	RARESCANNER_BUTTON.CloseButton:ClearAllPoints()
-	RARESCANNER_BUTTON.CloseButton:SetPoint("TOPRIGHT", -5, -5)
-	S:HandleButton(RARESCANNER_BUTTON.FilterEntityButton)
-	RARESCANNER_BUTTON.FilterEntityButton:SetNormalTexture([[Interface\WorldMap\Dash_64Grey]])
-	RARESCANNER_BUTTON.FilterEntityButton:ClearAllPoints()
-	RARESCANNER_BUTTON.FilterEntityButton:SetPoint("TOPLEFT", 5, -5)
-	S:HandleButton(RARESCANNER_BUTTON.UnfilterEnabledButton)
-	RARESCANNER_BUTTON.FilterEnabledTexture:SetTexture([[Interface\WorldMap\Skull_64]])
-	RARESCANNER_BUTTON.UnfilterEnabledButton:ClearAllPoints()
-	RARESCANNER_BUTTON.UnfilterEnabledButton:SetPoint("TOPLEFT", 5, -5)
+	local frame = RARESCANNER_BUTTON
+	if not frame then return end
+
+	S:HandleFrame(frame, 'Default')
+
+	if frame.CloseButton then
+		S:HandleButton(frame.CloseButton)
+		frame.CloseButton:ClearAllPoints()
+		frame.CloseButton:SetPoint("TOPRIGHT", -5, -5)
+	end
+
+	if frame.FilterEntityButton then
+		S:HandleButton(frame.FilterEntityButton)
+		frame.FilterEntityButton:SetNormalTexture([[Interface\WorldMap\Dash_64Grey]])
+		frame.FilterEntityButton:ClearAllPoints()
+		frame.FilterEntityButton:SetPoint("TOPLEFT", 5, -5)
+	end
+
+	if frame.FilterEnabledTexture then
+		frame.FilterEnabledTexture:SetTexture([[Interface\WorldMap\Skull_64]])
+	end
+
+	if frame.UnfilterEnabledButton then
+		S:HandleButton(frame.UnfilterEnabledButton)
+		frame.UnfilterEnabledButton:ClearAllPoints()
+		frame.UnfilterEnabledButton:SetPoint("TOPLEFT", 5, -5)
+	end
 end
 
 AS:RegisterSkin('RareScanner')

--- a/AddOnSkins/Skins/AddOns/SilverDragon.lua
+++ b/AddOnSkins/Skins/AddOns/SilverDragon.lua
@@ -1,38 +1,61 @@
 local AS, L, S, R = unpack(AddOnSkins)
 
 function R:SilverDragon()
-	local SilverDragon = LibStub("AceAddon-3.0"):GetAddon("SilverDragon")
-	local module = SilverDragon:GetModule("ClickTarget")
-	local original = module.Looks.SilverDragon
-	function module.Looks:SilverDragon(popup)
-		original(self, popup)
+	local SD = LibStub("AceAddon-3.0"):GetAddon("SilverDragon", true)
+	if not SD then return end
 
-		S:HandleFrame(popup)
+	local module = SD:GetModule("ClickTarget", true)
+	if not module then return end
 
-		S:HandleCloseButton(popup.close, true)
-		popup.close.backdrop:SetPoint('TOPLEFT', 7, -8)
-		popup.close.backdrop:SetPoint('BOTTOMRIGHT', -8, 8)
-		popup.close:ClearAllPoints()
-		popup.close:SetFrameLevel(popup:GetFrameLevel() + 2)
-		popup.close:SetPoint("TOPRIGHT", popup, 'TOPRIGHT', 4, 4)
-		popup.close:SetScale(1)
-		popup.close:HookScript("OnEnter", function(self)
-			self.Text:SetTextColor(1, .2, .2)
-			self.backdrop:SetBackdropBorderColor(1, .2, .2)
-		end)
+	local origApplyLook = module.ApplyLook
+	if type(origApplyLook) ~= 'function' then return end
 
-		popup.close:HookScript("OnLeave", function(self)
-			self.Text:SetTextColor(1, 1, 1)
-			self.backdrop:SetBackdropBorderColor(unpack(AS.BorderColor))
-		end)
+	module.ApplyLook = function(mod, popup, look)
+		origApplyLook(mod, popup, look)
+		if not popup then return end
 
-		popup.title:SetFont(AS.Libs.LSM:Fetch('font', AS:CheckOption('DBMFont')), AS:CheckOption('DBMFontSize'), AS:CheckOption('DBMFontFlag'))
-		popup.source:SetFont(AS.Libs.LSM:Fetch('font', AS:CheckOption('DBMFont')), AS:CheckOption('DBMFontSize'), AS:CheckOption('DBMFontFlag'))
-		popup.source:SetTextColor(1.0, 1.0, 1.0)
-		popup.status:SetFont(AS.Libs.LSM:Fetch('font', AS:CheckOption('DBMFont')), AS:CheckOption('DBMFontSize'), AS:CheckOption('DBMFontFlag'))
-		popup.status:SetTextColor(1.0, 1.0, 1.0)
+		if not popup.SD_Skinned then
+			popup.SD_Skinned = true
+			S:SetTemplate(popup)
+
+			if popup.close then
+				S:HandleCloseButton(popup.close, true)
+
+				if popup.close.backdrop then
+					popup.close.backdrop:SetPoint('TOPLEFT', 7, -8)
+					popup.close.backdrop:SetPoint('BOTTOMRIGHT', -8, 8)
+				end
+
+				popup.close:ClearAllPoints()
+				popup.close:SetFrameLevel(popup:GetFrameLevel() + 2)
+				popup.close:SetPoint("TOPRIGHT", popup, 'TOPRIGHT', 4, 4)
+				popup.close:SetScale(1)
+
+				popup.close:HookScript("OnEnter", function(btn)
+					if btn.Text then btn.Text:SetTextColor(1, .2, .2) end
+					if btn.backdrop then btn.backdrop:SetBackdropBorderColor(1, .2, .2) end
+				end)
+
+				popup.close:HookScript("OnLeave", function(btn)
+					if btn.Text then btn.Text:SetTextColor(1, 1, 1) end
+					if btn.backdrop then btn.backdrop:SetBackdropBorderColor(unpack(AS.BorderColor)) end
+				end)
+			end
+		end
+
+		local font = AS.Libs.LSM:Fetch('font', AS:CheckOption('DBMFont'))
+		local fontSize = AS:CheckOption('DBMFontSize')
+		local fontFlag = AS:CheckOption('DBMFontFlag')
+		if popup.title then popup.title:SetFont(font, fontSize, fontFlag) end
+		if popup.source then
+			popup.source:SetFont(font, fontSize, fontFlag)
+			popup.source:SetTextColor(1.0, 1.0, 1.0)
+		end
+		if popup.status then
+			popup.status:SetFont(font, fontSize, fontFlag)
+			popup.status:SetTextColor(1.0, 1.0, 1.0)
+		end
 	end
-
 end
 
 AS:RegisterSkin('SilverDragon')


### PR DESCRIPTION
- Bump interface version 110107 -> 120001 for Midnight expansion
- Version 4.79
- AllTheThings: wrap GetWindow lazily to avoid premature bare frame creation that caused ATT's Load method error
- RareScanner: add nil guards for all child elements
- SilverDragon: use plain Lua function replacement on module.ApplyLook instead of hooksecurefunc (which fails when ApplyLook is inherited via Ace3 class prototype metatable)